### PR TITLE
Emit end event when serial port 'ends' (device is removed from USB port)

### DIFF
--- a/lib/rfxcom.js
+++ b/lib/rfxcom.js
@@ -92,7 +92,10 @@ RfxCom.prototype.open = function() {
     });
 
     self.serialport.on("end", function() {
-        console.log("Received 'end'");
+        if (self.options.debug) {
+            console.log("Received: 'end'");
+        }
+        self.emit("end");
     });
 
     self.serialport.on("drain", function() {

--- a/test/rfxcom.spec.js
+++ b/test/rfxcom.spec.js
@@ -122,6 +122,17 @@ describe("RfxCom", function() {
                 device.open();
                 fakeSerialPort.emit("data", [0x01]);
             });
+            it("should emit an end message when serial port is closed (ends)", function(done) {
+                var fakeSerialPort = new FakeSerialPort(),
+                    device = new rfxcom.RfxCom("/dev/ttyUSB0", {
+                        port: fakeSerialPort
+                    });
+                device.on("end", function(evt) {
+                    done();
+                });
+                device.open();
+                fakeSerialPort.emit("end");
+            });
         });
 
         describe(".initialise should prepare the device for use", function() {


### PR DESCRIPTION
I made this change to make it more resilient to USB cable being pulled in and out.