### PR TITLE
Switch to v2 of node-serialport

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.7.9",
   "author": "Kevin McDermott <kevin@bigkevmcd.com>",
   "dependencies": {
-    "serialport": "~1.4.0"
+    "serialport": "~2.0.0"
   },
   "main": "rfxcom.js",
   "devDependencies": {


### PR DESCRIPTION
The 1.4.0 release of node-serialport doesn't build on OpenBSD. This is fixed a subsequent release.